### PR TITLE
Make the code faster by uglifying it to fit in '#%kernel.

### DIFF
--- a/find-collection/.gitignore
+++ b/find-collection/.gitignore
@@ -1,0 +1,2 @@
+compiled/
+*~

--- a/find-collection/fast.rkt
+++ b/find-collection/fast.rkt
@@ -1,0 +1,13 @@
+#lang racket/kernel
+
+(#%require "find-collection.rkt")
+
+(let*-values ([(collection-path) (vector-ref (current-command-line-arguments) 0)]
+              [(dir) (find-collection-dir collection-path)])
+  (if dir
+      (begin (write-string (path->string dir)) (newline))
+      (begin (write-string (path->string (current-directory)))
+             (newline)
+             (error 'raco-find-collection
+                    "could not find the collection path ~v"
+                    collection-path))))

--- a/find-collection/find-collection.rkt
+++ b/find-collection/find-collection.rkt
@@ -1,18 +1,23 @@
-#lang racket/base
+#lang racket/kernel
 
-(provide find-collection-dir)
+(#%require '#%utils)
+(#%provide find-collection-dir)
 
-(define (find-collection-dir collection)
-  (collection-path
-   collection
-   #:fail (λ (_0)
-            (define-values (base name _1)
-              (split-path collection))
-            (define file-path
-              (collection-file-path name base #:fail (λ (_) #f)))
-            (and file-path
-                 (file-exists? file-path)
-                 (let-values ([(collection-base _2 _3)
-                               (split-path (collection-file-path name base))])
-                   collection-base)))))
+(define-values (find-collection-dir)
+  (lambda (collection)
+    (collection-path
+     (λ (_0)
+        (define-values (base name _1)
+          (split-path collection))
+        (define-values (file-path)
+          (collection-file-path (λ (_) #f) name base))
+        (if file-path
+            (if (file-exists? file-path)
+                (let-values ([(collection-base _2 _3)
+                              (split-path (collection-file-path name base))])
+                  collection-base)
+                #f)
+            #f))
+     collection)))
+
 


### PR DESCRIPTION
With my changes, 'racket fast.rkt mrlib' is about 15 ms, whereas 'racket
run.rkt mrlib' is about 30+ ms before.