### PR TITLE
add -s option

### DIFF
--- a/find-collection/find-collection.rkt
+++ b/find-collection/find-collection.rkt
@@ -1,10 +1,11 @@
 #lang racket/base
 
-(require racket/path pkg/path
+(require racket/path pkg/path pkg/lib
          setup/getinfo
          (submod compiler/commands/test paths))
 
 (provide find-collection-dir
+         find-source
          raco-name->collection-path)
 
 ;; Path-String -> (Listof Path)
@@ -36,6 +37,21 @@
                          (split-path file-path)])
              (list collection-base)))
       null))
+
+;; String -> String
+(define (find-source pkg-name)
+  (define (pkg-not-found e)
+    (raise-user-error 'raco-find-collection
+                      "could not find the package ~v"
+                      pkg-name))
+  (define (source-not-found)
+    (raise-user-error 'raco-find-collection
+                      "could not find source for package ~v"
+                      pkg-name))
+  (define details
+    (with-handlers ([exn:fail? pkg-not-found])
+      (get-pkg-details-from-catalogs pkg-name)))
+  (hash-ref details 'source source-not-found))
 
 (define cache (make-hash))
 

--- a/find-collection/raco-fc.scrbl
+++ b/find-collection/raco-fc.scrbl
@@ -46,3 +46,16 @@ current directory (for convenience in scripts that use cd).
 If you supply the @exec{-i} option, the tool will ask you to
 disambiguate when there are multiple matches by printing to
 standard error. Enter a numeric response to choose a match.
+
+
+@subsection{Find a Package's Source}
+@(define (pkgtech #:key [key #f] . args)
+   @tech[#:doc '(lib "pkg/scribblings/pkg.scrbl") #:key key args])
+
+The invocation
+@;
+@nested[#:style 'inset @exec{raco fc -s <pkg-name>}]
+@;
+consults the @pkgtech{package catalogs} for information about the given
+@pkgtech{package name} and prints the package's
+@pkgtech[#:key "package-source"]{source}.


### PR DESCRIPTION
`raco fc -s <pkg-name>`

searches the catalogs for the "source" of `<pkg-name>` (usually a URL)
and prints it.

On second thought I'm not sure how useful this is, but it seemed to me like something that `raco fc` should do. 