### PR TITLE
Rephrasing the description of the raco command

### DIFF
--- a/find-collection/info.rkt
+++ b/find-collection/info.rkt
@@ -1,6 +1,6 @@
 #lang setup/infotab
 
 (define raco-commands
-  '(("fc" find-collection/run "change directory to given collection's location" #f)))
+  '(("fc" find-collection/run "find given collection's location" #f)))
 (define scribblings
   '(("raco-fc.scrbl" () (tool))))


### PR DESCRIPTION
The command itself simply returns the path as a string.